### PR TITLE
refactor: extract token expiry as named constant in auth service

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -7,27 +7,25 @@ from app.repositories.user_repo import find_by_username, create_user
 from app.core.password_hasher import verify_password
 
 SECRET_KEY = os.getenv("SECRET_KEY", "bytebites-dev-secret")
+TOKEN_EXPIRE_HOURS = 1  # extracted as constant for easy configuration
 
 def register(db: Session, username: str, password: str):
-    # Check if username is already taken
+    """Register a new user, raises 400 if username already exists."""
     if find_by_username(db, username):
         raise HTTPException(status_code=400, detail="Username already taken")
-    
     user = create_user(db, username, password)
     return {"id": user.id, "username": user.username, "role": user.role}
 
 def login(db: Session, username: str, password: str):
-    # Find the user and check their password
+    """Authenticate user credentials and return a JWT token."""
     user = find_by_username(db, username)
     if not user or not verify_password(password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid username or password")
-    
-    # Create a JWT token that expires in 1 hour
     token = jwt.encode(
         {
-            "sub": user.id,        # who the token belongs to
-            "role": user.role,     # their role for RBAC
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1)
+            "sub": user.id,
+            "role": user.role,
+            "exp": datetime.now(timezone.utc) + timedelta(hours=TOKEN_EXPIRE_HOURS)
         },
         SECRET_KEY,
         algorithm="HS256"


### PR DESCRIPTION
Extracts the hardcoded token expiry value into a named constant for better readability and easier configuration.


- TOKEN_EXPIRE_HOURS = 1 defined at the top of the file
- login function references the constant instead of a magic number

This makes it easier to change the expiry time in one place without hunting through the code.